### PR TITLE
Merge branch '#1'

### DIFF
--- a/src/NetEx.Legacy.WinForms/Compatibility/NotifyIconExtensionMethods.cs
+++ b/src/NetEx.Legacy.WinForms/Compatibility/NotifyIconExtensionMethods.cs
@@ -38,7 +38,7 @@ namespace System.Windows.Forms
             contextMenu.OnPopup(EventArgs.Empty);
 
             SafeNativeMethods.TrackPopupMenuEx(new HandleRef(contextMenu, contextMenu.Handle),
-                NativeMethods.TPM_VERTICAL | NativeMethods.TPM_RIGHTALIGN,
+                NativeMethods.TPM_VERTICAL | NativeMethods.TPM_LEFTALIGN,
                 pos.X, //pt.x,
                 pos.Y, //pt.y,
                 new HandleRef(window, windowHandle),


### PR DESCRIPTION
Menu alignment is now `TPM_LEFTALIGN` instead of `TPM_RIGHTALIGN` so menus align consistent with expected behaviour when shown from a `NotifyIcon`.

Fix: #1